### PR TITLE
Centralize Firebase setup with App Check

### DIFF
--- a/components/jobSearchEntry.tsx
+++ b/components/jobSearchEntry.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import { push, ref, update } from "firebase/database";
 import { useObjectVal } from "react-firebase-hooks/database";
 
-import { db } from 'src/pages/_app'
+import { rtdb } from 'src/utils/firebaseClient'
 import Head from "next/head";
 import Nav from "src/components/nav";
 import { useRouter } from "next/router";
@@ -54,7 +54,7 @@ export function useAuth() : Auth | null{
     }, [auth]);
    
     // get database reference if mode is "update"
-    const databaseRef = mode === "update" ? ref(db, `jobs/${jobSearchEntryId}`) : null;
+    const databaseRef = mode === "update" ? ref(rtdb, `jobs/${jobSearchEntryId}`) : null;
     // Use the useObjectVal hook to get the data, loading indicator, and error object
     const [data, loading, error] = useObjectVal<any>(databaseRef);
     
@@ -177,8 +177,8 @@ export function useAuth() : Auth | null{
             applicationStatus: applicationStatus,
             salary: salary
         };
-        // push new job to firebase database
-        push(ref(db, 'jobs'), newJob)
+          // push new job to firebase database
+          push(ref(rtdb, 'jobs'), newJob)
         .then(() => {
             // set isSubmitting to false to enable form
             setIsSubmitting(false);
@@ -221,8 +221,8 @@ export function useAuth() : Auth | null{
         applicationStatus: applicationStatus,
         salary: salary
     };
-    // update existing job in firebase database
-    update(ref(db, `jobs/${jobSearchEntryId}`), updatedJob)
+      // update existing job in firebase database
+      update(ref(rtdb, `jobs/${jobSearchEntryId}`), updatedJob)
     .then(() => {
         // set isSubmitting to false to enable form
         setIsSubmitting(false);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,37 +1,8 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
+import { app, auth, db, rtdb } from 'src/utils/firebaseClient'
 
-// Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
-// add database
-import { getDatabase } from "firebase/database";
-import { useEffect, useState } from 'react';
-import { getAuth } from 'firebase/auth';
-// https://firebase.google.com/docs/web/setup#available-libraries
-
-// Your web app's Firebase configuration
-
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
-
-};
-
-
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
-// get database and export
-export const db = getDatabase(app);
-
-// get auth and export
-export const auth = getAuth(app);
-
+export { app, auth, db, rtdb }
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />

--- a/pages/projects/job-search-log.tsx
+++ b/pages/projects/job-search-log.tsx
@@ -5,8 +5,7 @@ import styles from 'src/styles/JobSearchLog.module.css'
 import { useEffect, useState } from 'react';
 // import firebase
 import { ref, onValue } from "firebase/database";
-//import db from _app.tsx
-import { db } from 'src/pages/_app'
+import { rtdb } from 'src/utils/firebaseClient'
 import Link from 'next/link';
 import React from 'react';
 
@@ -15,7 +14,7 @@ export default function JobSearchLog() {
     const [jobData, setJobData] = useState<any[]>([]);
     useEffect(() => {
         // get data from firebase sorted by dateApplied
-        const dbRef = ref(db, 'jobs');
+        const dbRef = ref(rtdb, 'jobs');
         onValue(dbRef, (snapshot) => {
             const data = snapshot.val();
             const jobData = [];

--- a/utils/firebaseClient.ts
+++ b/utils/firebaseClient.ts
@@ -8,6 +8,7 @@ import {
 } from "firebase/app-check";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
+import { getDatabase } from "firebase/database";
 
 
 const firebaseConfig = {
@@ -21,19 +22,22 @@ const firebaseConfig = {
 
 export const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const rtdb = getDatabase(app); // Realtime DB
 
 let appCheck: AppCheck | undefined;
 if (typeof window !== "undefined" && !appCheck) {
   // Enable debug only in dev if needed
   // @ts-ignore
-  self.FIREBASE_APPCHECK_DEBUG_TOKEN = process.env.NEXT_PUBLIC_FB_APPCHECK_DEBUG === "true";
+  self.FIREBASE_APPCHECK_DEBUG_TOKEN =
+    process.env.NEXT_PUBLIC_FB_APPCHECK_DEBUG === "true";
   appCheck = initializeAppCheck(app, {
-    provider: new ReCaptchaV3Provider(process.env.NEXT_PUBLIC_FB_RECAPTCHA_V3_SITE_KEY!),
+    provider: new ReCaptchaV3Provider(
+      process.env.NEXT_PUBLIC_FB_RECAPTCHA_V3_SITE_KEY!
+    ),
     isTokenAutoRefreshEnabled: true,
   });
 }
-
-export const db = getFirestore(app);
 
 export async function getAppCheckHeader() {
   if (typeof window === "undefined" || !appCheck) return {};


### PR DESCRIPTION
## Summary
- centralize Firebase app initialization and App Check in `utils/firebaseClient`
- strip Firebase config from `_app.tsx` and re-export Firebase instances
- refactor job search log components to import Realtime Database from centralized client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe231ca5883219f3b58f5feccdf63