### PR TITLE
refactor: remove server-only import from firebase admin util

### DIFF
--- a/utils/firebaseAdmin.ts
+++ b/utils/firebaseAdmin.ts
@@ -1,5 +1,9 @@
-import "server-only";
 import * as admin from "firebase-admin";
+
+// Ensure this file is only executed in a server-side context.
+if (typeof window !== "undefined") {
+  throw new Error("firebaseAdmin must be used only on the server");
+}
 
 const credential =
   process.env.GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
## Summary
- remove `server-only` directive from Firebase Admin utility and add a runtime guard
- confirm usage from API routes only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'firebase-admin/app-check')*

------
https://chatgpt.com/codex/tasks/task_e_68bd0a01c7bc8321852d73a951da8b57