### PR TITLE
refactor: ensure Firebase services use shared initializer

### DIFF
--- a/components/gptJobEntry.tsx
+++ b/components/gptJobEntry.tsx
@@ -1,4 +1,5 @@
-import { getAuth, signInWithPopup, GoogleAuthProvider, Auth, User } from "firebase/auth";
+import { signInWithPopup, GoogleAuthProvider, Auth, User } from "firebase/auth";
+import { getAuthC } from 'src/utils/firebaseClient';
 import Head from "next/head";
 import React, { useEffect, useState } from "react";
 import Nav from "./nav";
@@ -12,7 +13,7 @@ export function useAuth() : Auth | null{
     useEffect(() => {
       // initialize firebase auth only once
       if (!auth) {
-        setAuth(getAuth());
+        setAuth(getAuthC());
       }
     }, [auth]);
   

--- a/components/jobSearchEntry.tsx
+++ b/components/jobSearchEntry.tsx
@@ -5,11 +5,11 @@ import React, { useEffect, useState } from "react";
 import { push, ref, update } from "firebase/database";
 import { useObjectVal } from "react-firebase-hooks/database";
 
-import { rtdb } from 'src/utils/firebaseClient'
+import { getRtdb, getAuthC } from 'src/utils/firebaseClient'
 import Head from "next/head";
 import Nav from "src/components/nav";
 import { useRouter } from "next/router";
-import { getAuth, signInWithPopup, GoogleAuthProvider, Auth, User } from "firebase/auth";
+import { signInWithPopup, GoogleAuthProvider, Auth, User } from "firebase/auth";
 import router from "next/router";
 // import styles
 import styles from 'src/styles/NewJobSearchLog.module.css'
@@ -23,7 +23,7 @@ export function useAuth() : Auth | null{
     useEffect(() => {
       // initialize firebase auth only once
       if (!auth) {
-        setAuth(getAuth());
+        setAuth(getAuthC());
       }
     }, [auth]);
   
@@ -53,6 +53,7 @@ export function useAuth() : Auth | null{
         return unsubscribe;
     }, [auth]);
    
+    const rtdb = getRtdb();
     // get database reference if mode is "update"
     const databaseRef = mode === "update" ? ref(rtdb, `jobs/${jobSearchEntryId}`) : null;
     // Use the useObjectVal hook to get the data, loading indicator, and error object

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,5 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
-import { app, auth, db, rtdb } from 'src/utils/firebaseClient'
-
-export { app, auth, db, rtdb }
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />

--- a/pages/projects/job-search-log.tsx
+++ b/pages/projects/job-search-log.tsx
@@ -5,7 +5,7 @@ import styles from 'src/styles/JobSearchLog.module.css'
 import { useEffect, useState } from 'react';
 // import firebase
 import { ref, onValue } from "firebase/database";
-import { rtdb } from 'src/utils/firebaseClient'
+import { getRtdb } from 'src/utils/firebaseClient'
 import Link from 'next/link';
 import React from 'react';
 
@@ -13,6 +13,7 @@ export default function JobSearchLog() {
     // get data from firebase. need to set types. fixed in next line
     const [jobData, setJobData] = useState<any[]>([]);
     useEffect(() => {
+        const rtdb = getRtdb();
         // get data from firebase sorted by dateApplied
         const dbRef = ref(rtdb, 'jobs');
         onValue(dbRef, (snapshot) => {


### PR DESCRIPTION
## Summary
- use shared `getAuthC` and `getRtdb` helpers across job log components
- remove outdated firebase exports from _app
- access realtime database through helper in job-search-log page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd303d9bc48321a3fe1a5312f2828b