### PR TITLE
Add knitting visualizer MVP page with chart editor and RS/WS fabric preview

### DIFF
--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -35,6 +35,7 @@ export default function Projects() {
                         <li><Link href="projects/slider">Gamepad Audio Control</Link></li>
                         <li><Link href="projects/cellularAutomata/">Cellular Automata</Link></li>
                         <li><Link href="projects/fizzbuzz">FizzBuzz</Link></li>
+                        <li><Link href="projects/knitting-visualizer">Knitting Visualizer</Link><ul><li>Interactive knit/purl stitch chart editor with RS/WS fabric preview.</li></ul></li>
                         <li><Link href="/pokemon.html">Experimenting with P5.js</Link></li>
                     </ul>
                 </li>

--- a/pages/projects/knitting-visualizer.tsx
+++ b/pages/projects/knitting-visualizer.tsx
@@ -143,6 +143,7 @@ export default function KnittingVisualizer() {
 
           <div>
             <h2>Fabric view ({viewSide})</h2>
+            <p className={styles.fabricHint}>V-shape = knit stitch, bump = purl stitch.</p>
             <div
               className={styles.grid}
               style={{ gridTemplateColumns: `40px repeat(${cols}, minmax(24px, 1fr))` }}
@@ -155,10 +156,11 @@ export default function KnittingVisualizer() {
                     {row.map((stitch, c) => (
                       <div
                         key={`f-${r}-${c}`}
-                        className={`${styles.cell} ${stitch === "K" ? styles.knit : styles.purl}`}
+                        className={`${styles.cell} ${styles.fabricCell} ${stitch === "K" ? styles.knitTexture : styles.purlTexture}`}
                         title={`Visible on ${viewSide}: ${stitch}`}
+                        aria-label={`Visible stitch row ${rowNumber} stitch ${c + 1}: ${stitch}`}
                       >
-                        {stitch === "K" ? "V" : "•"}
+                        <span className={styles.stitchMark} aria-hidden="true" />
                       </div>
                     ))}
                   </Fragment>

--- a/pages/projects/knitting-visualizer.tsx
+++ b/pages/projects/knitting-visualizer.tsx
@@ -5,17 +5,69 @@ import styles from "../../styles/KnittingVisualizer.module.css";
 
 type Stitch = "K" | "P";
 type Side = "RS" | "WS";
+type FabricMode = "yarn" | "symbol";
 
 const createGrid = (rows: number, cols: number, fill: Stitch = "K") =>
   Array.from({ length: rows }, () => Array.from({ length: cols }, () => fill));
 
 const oppositeStitch = (stitch: Stitch): Stitch => (stitch === "K" ? "P" : "K");
 
+type StitchGlyphOpts = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+const knitLoopPath = ({ x, y, w, h }: StitchGlyphOpts) => {
+  const insetX = w * 0.22;
+  const topY = y + h * 0.12;
+  const midY = y + h * 0.52;
+  const botY = y + h * 0.88;
+
+  const leftX = x + insetX;
+  const rightX = x + w - insetX;
+  const cx = x + w / 2;
+
+  return `
+    M ${leftX} ${topY}
+    C ${leftX} ${midY}, ${cx - w * 0.18} ${midY}, ${cx - w * 0.12} ${botY}
+    C ${cx - w * 0.06} ${botY + h * 0.06}, ${cx + w * 0.06} ${botY + h * 0.06}, ${cx + w * 0.12} ${botY}
+    C ${cx + w * 0.18} ${midY}, ${rightX} ${midY}, ${rightX} ${topY}
+  `;
+};
+
+const purlBumpRects = ({ x, y, w, h }: StitchGlyphOpts) => {
+  const bumpW = w * 0.62;
+  const bumpH = h * 0.2;
+  const bx = x + (w - bumpW) / 2;
+  const by = y + h * 0.52;
+
+  const shadow = {
+    x: bx + w * 0.03,
+    y: by + h * 0.03,
+    w: bumpW,
+    h: bumpH,
+    r: bumpH / 2,
+  };
+
+  const main = { x: bx, y: by, w: bumpW, h: bumpH, r: bumpH / 2 };
+
+  return { shadow, main };
+};
+
 export default function KnittingVisualizer() {
   const [rows, setRows] = useState(12);
   const [cols, setCols] = useState(12);
   const [viewSide, setViewSide] = useState<Side>("RS");
+  const [fabricMode, setFabricMode] = useState<FabricMode>("yarn");
   const [chart, setChart] = useState<Stitch[][]>(() => createGrid(12, 12, "K"));
+
+  const cellSize = 28;
+  const rowPitch = Math.round(cellSize * 0.72);
+  const labelWidth = 40;
+  const fabricWidth = labelWidth + cols * cellSize;
+  const fabricHeight = rows * rowPitch + cellSize * 0.5;
 
   const resizeChart = (nextRows: number, nextCols: number) => {
     setChart((prev) =>
@@ -103,6 +155,16 @@ export default function KnittingVisualizer() {
               <option value="WS">WS (wrong side)</option>
             </select>
           </label>
+          <label>
+            Fabric style
+            <select
+              value={fabricMode}
+              onChange={(e) => setFabricMode(e.target.value as FabricMode)}
+            >
+              <option value="yarn">Yarn glyphs</option>
+              <option value="symbol">Symbol fallback</option>
+            </select>
+          </label>
           <div className={styles.buttonRow}>
             <button type="button" onClick={() => fillChart("K")}>Fill K</button>
             <button type="button" onClick={() => fillChart("P")}>Fill P</button>
@@ -143,29 +205,89 @@ export default function KnittingVisualizer() {
 
           <div>
             <h2>Fabric view ({viewSide})</h2>
-            <p className={styles.fabricHint}>V-shape = knit stitch, bump = purl stitch.</p>
-            <div
-              className={styles.grid}
-              style={{ gridTemplateColumns: `40px repeat(${cols}, minmax(24px, 1fr))` }}
-            >
-              {fabric.map((row, r) => {
-                const rowNumber = rows - r;
-                return (
-                  <Fragment key={`fabric-row-${rowNumber}`}>
-                    <div className={styles.rowLabel}>{rowNumber}</div>
-                    {row.map((stitch, c) => (
-                      <div
-                        key={`f-${r}-${c}`}
-                        className={`${styles.cell} ${styles.fabricCell} ${stitch === "K" ? styles.knitTexture : styles.purlTexture}`}
-                        title={`Visible on ${viewSide}: ${stitch}`}
-                        aria-label={`Visible stitch row ${rowNumber} stitch ${c + 1}: ${stitch}`}
-                      >
-                        <span className={styles.stitchMark} aria-hidden="true" />
-                      </div>
-                    ))}
-                  </Fragment>
-                );
-              })}
+            <p className={styles.fabricHint}>K = knit loop, P = purl bump. Rows overlap to mimic interlocked fabric.</p>
+            <div className={styles.fabricWrap}>
+              <svg
+                className={styles.fabricSvg}
+                viewBox={`0 0 ${fabricWidth} ${fabricHeight}`}
+                role="img"
+                aria-label={`Fabric preview on ${viewSide} with ${fabricMode} style`}
+              >
+                <rect x="0" y="0" width={fabricWidth} height={fabricHeight} fill="#e9c7a5" />
+                {fabric.map((row, r) => {
+                  const rowNumber = rows - r;
+                  const y = r * rowPitch;
+
+                  return (
+                    <Fragment key={`fabric-row-${rowNumber}`}>
+                      <text x={labelWidth - 4} y={y + cellSize * 0.62} textAnchor="end" className={styles.fabricLabel}>
+                        {rowNumber}
+                      </text>
+                      {row.map((stitch, c) => {
+                        const x = labelWidth + c * cellSize;
+                        const isKnit = stitch === "K";
+                        const loopColor = isKnit ? "#7c563b" : "#8d6245";
+
+                        if (fabricMode === "symbol") {
+                          return (
+                            <g key={`f-${r}-${c}`}>
+                              <text
+                                x={x + cellSize / 2}
+                                y={y + cellSize * 0.65}
+                                textAnchor="middle"
+                                className={styles.fabricSymbol}
+                              >
+                                {isKnit ? "V" : "•"}
+                              </text>
+                            </g>
+                          );
+                        }
+
+                        if (isKnit) {
+                          return (
+                            <path
+                              key={`f-${r}-${c}`}
+                              d={knitLoopPath({ x, y, w: cellSize, h: cellSize })}
+                              fill="none"
+                              stroke={loopColor}
+                              strokeWidth={2.7}
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              opacity={0.96}
+                            />
+                          );
+                        }
+
+                        const { shadow, main } = purlBumpRects({ x, y, w: cellSize, h: cellSize });
+                        return (
+                          <g key={`f-${r}-${c}`}>
+                            <rect
+                              x={shadow.x}
+                              y={shadow.y}
+                              width={shadow.w}
+                              height={shadow.h}
+                              rx={shadow.r}
+                              ry={shadow.r}
+                              fill="black"
+                              opacity={0.13}
+                            />
+                            <rect
+                              x={main.x}
+                              y={main.y}
+                              width={main.w}
+                              height={main.h}
+                              rx={main.r}
+                              ry={main.r}
+                              fill="#80593d"
+                              opacity={0.93}
+                            />
+                          </g>
+                        );
+                      })}
+                    </Fragment>
+                  );
+                })}
+              </svg>
             </div>
           </div>
         </section>

--- a/pages/projects/knitting-visualizer.tsx
+++ b/pages/projects/knitting-visualizer.tsx
@@ -1,0 +1,173 @@
+import Head from "next/head";
+import { Fragment, useMemo, useState } from "react";
+import Nav from "src/components/nav";
+import styles from "../../styles/KnittingVisualizer.module.css";
+
+type Stitch = "K" | "P";
+type Side = "RS" | "WS";
+
+const createGrid = (rows: number, cols: number, fill: Stitch = "K") =>
+  Array.from({ length: rows }, () => Array.from({ length: cols }, () => fill));
+
+const oppositeStitch = (stitch: Stitch): Stitch => (stitch === "K" ? "P" : "K");
+
+export default function KnittingVisualizer() {
+  const [rows, setRows] = useState(12);
+  const [cols, setCols] = useState(12);
+  const [viewSide, setViewSide] = useState<Side>("RS");
+  const [chart, setChart] = useState<Stitch[][]>(() => createGrid(12, 12, "K"));
+
+  const resizeChart = (nextRows: number, nextCols: number) => {
+    setChart((prev) =>
+      Array.from({ length: nextRows }, (_, r) =>
+        Array.from({ length: nextCols }, (_, c) => prev[r]?.[c] ?? "K"),
+      ),
+    );
+  };
+
+  const toggleStitch = (r: number, c: number) => {
+    setChart((prev) => {
+      const next = prev.map((row) => [...row]);
+      next[r][c] = next[r][c] === "K" ? "P" : "K";
+      return next;
+    });
+  };
+
+  const fillChart = (stitch: Stitch) => {
+    setChart(createGrid(rows, cols, stitch));
+  };
+
+  const fabric = useMemo(
+    () =>
+      chart.map((row, r) => {
+        const rowNumberFromBottom = rows - r;
+        const workedSide: Side = rowNumberFromBottom % 2 === 1 ? "RS" : "WS";
+
+        return row.map((stitch) =>
+          viewSide === workedSide ? stitch : oppositeStitch(stitch),
+        );
+      }),
+    [chart, rows, viewSide],
+  );
+
+  return (
+    <>
+      <Head>
+        <title>Knitting Visualizer</title>
+        <meta
+          name="description"
+          content="2D stitch-chart editor + fabric preview for knit/purl textures"
+        />
+      </Head>
+      <Nav />
+      <main className={`main ${styles.page}`}>
+        <h1>Knitting Visualizer (K/P MVP)</h1>
+        <p className={styles.lead}>
+          Edit the chart as stitches you work. Fabric preview converts stitches based
+          on whether you are viewing the right side (RS) or wrong side (WS).
+        </p>
+
+        <section className={styles.controls}>
+          <label>
+            Rows
+            <input
+              type="number"
+              min={1}
+              max={60}
+              value={rows}
+              onChange={(e) => {
+                const nextRows = Math.max(1, Math.min(60, Number(e.target.value) || 1));
+                setRows(nextRows);
+                resizeChart(nextRows, cols);
+              }}
+            />
+          </label>
+          <label>
+            Columns
+            <input
+              type="number"
+              min={1}
+              max={60}
+              value={cols}
+              onChange={(e) => {
+                const nextCols = Math.max(1, Math.min(60, Number(e.target.value) || 1));
+                setCols(nextCols);
+                resizeChart(rows, nextCols);
+              }}
+            />
+          </label>
+          <label>
+            Fabric side
+            <select value={viewSide} onChange={(e) => setViewSide(e.target.value as Side)}>
+              <option value="RS">RS (right side)</option>
+              <option value="WS">WS (wrong side)</option>
+            </select>
+          </label>
+          <div className={styles.buttonRow}>
+            <button type="button" onClick={() => fillChart("K")}>Fill K</button>
+            <button type="button" onClick={() => fillChart("P")}>Fill P</button>
+          </div>
+        </section>
+
+        <section className={styles.visualizers}>
+          <div>
+            <h2>Chart view (what you work)</h2>
+            <div
+              className={styles.grid}
+              style={{ gridTemplateColumns: `40px repeat(${cols}, minmax(24px, 1fr))` }}
+            >
+              {chart.map((row, r) => {
+                const rowNumber = rows - r;
+                const direction = rowNumber % 2 === 1 ? "←" : "→";
+                return (
+                  <Fragment key={`chart-row-${rowNumber}`}>
+                    <div className={styles.rowLabel}>
+                      {rowNumber} {direction}
+                    </div>
+                    {row.map((stitch, c) => (
+                      <button
+                        key={`${r}-${c}`}
+                        type="button"
+                        className={`${styles.cell} ${stitch === "K" ? styles.knit : styles.purl}`}
+                        onClick={() => toggleStitch(r, c)}
+                        aria-label={`Row ${rowNumber}, stitch ${c + 1}, ${stitch}`}
+                      >
+                        {stitch}
+                      </button>
+                    ))}
+                  </Fragment>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <h2>Fabric view ({viewSide})</h2>
+            <div
+              className={styles.grid}
+              style={{ gridTemplateColumns: `40px repeat(${cols}, minmax(24px, 1fr))` }}
+            >
+              {fabric.map((row, r) => {
+                const rowNumber = rows - r;
+                return (
+                  <Fragment key={`fabric-row-${rowNumber}`}>
+                    <div className={styles.rowLabel}>{rowNumber}</div>
+                    {row.map((stitch, c) => (
+                      <div
+                        key={`f-${r}-${c}`}
+                        className={`${styles.cell} ${stitch === "K" ? styles.knit : styles.purl}`}
+                        title={`Visible on ${viewSide}: ${stitch}`}
+                      >
+                        {stitch === "K" ? "V" : "•"}
+                      </div>
+                    ))}
+                  </Fragment>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/styles/KnittingVisualizer.module.css
+++ b/styles/KnittingVisualizer.module.css
@@ -91,52 +91,30 @@ button.cell {
   font-size: 0.9rem;
 }
 
-.fabricCell {
-  position: relative;
-  background: #f2d4b6;
-  border-color: rgba(90, 62, 35, 0.25);
-  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.45);
+.fabricWrap {
+  background: #d7b089;
+  border-radius: 8px;
+  padding: 0.4rem;
+  overflow-x: auto;
 }
 
-.stitchMark {
-  position: relative;
+.fabricSvg {
   display: block;
-  width: 18px;
-  height: 18px;
+  min-width: 420px;
+  width: 100%;
+  height: auto;
 }
 
-.knitTexture .stitchMark::before,
-.knitTexture .stitchMark::after {
-  content: "";
-  position: absolute;
-  width: 3px;
-  height: 15px;
-  top: 1px;
-  background: #805b3f;
-  border-radius: 999px;
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.14);
+.fabricLabel {
+  font-size: 10px;
+  fill: #4b3322;
+  font-weight: 700;
 }
 
-.knitTexture .stitchMark::before {
-  left: 5px;
-  transform: rotate(26deg);
-}
-
-.knitTexture .stitchMark::after {
-  right: 5px;
-  transform: rotate(-26deg);
-}
-
-.purlTexture .stitchMark::before {
-  content: "";
-  position: absolute;
-  left: 3px;
-  right: 3px;
-  top: 5px;
-  height: 9px;
-  background: radial-gradient(circle at 50% 35%, #ffe8d2 0%, #d7a882 65%, #bf8862 100%);
-  border-radius: 999px;
-  box-shadow: 0 1px 0 rgba(92, 60, 34, 0.4), inset 0 1px 1px rgba(255, 255, 255, 0.5);
+.fabricSymbol {
+  font-size: 14px;
+  fill: #643f2a;
+  font-weight: 700;
 }
 
 @media (min-width: 960px) {

--- a/styles/KnittingVisualizer.module.css
+++ b/styles/KnittingVisualizer.module.css
@@ -1,0 +1,94 @@
+.page {
+  gap: 1rem;
+}
+
+.lead {
+  max-width: 900px;
+  text-align: center;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+  justify-content: center;
+  background: blanchedalmond;
+  border: 1px solid burlywood;
+  border-radius: 8px;
+  padding: 0.8rem;
+}
+
+.controls label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  gap: 0.3rem;
+}
+
+.controls input,
+.controls select,
+.buttonRow button {
+  font: inherit;
+  padding: 0.3rem 0.5rem;
+}
+
+.buttonRow {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.visualizers {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 2px;
+  background: burlywood;
+  padding: 4px;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.rowLabel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  background: floralwhite;
+}
+
+.cell {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+  min-height: 28px;
+  min-width: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #222;
+}
+
+button.cell {
+  cursor: pointer;
+}
+
+.knit {
+  background: #b6e3ff;
+}
+
+.purl {
+  background: #ffd9cc;
+}
+
+@media (min-width: 960px) {
+  .visualizers {
+    grid-template-columns: 1fr 1fr;
+    align-items: flex-start;
+  }
+}

--- a/styles/KnittingVisualizer.module.css
+++ b/styles/KnittingVisualizer.module.css
@@ -86,6 +86,59 @@ button.cell {
   background: #ffd9cc;
 }
 
+.fabricHint {
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+}
+
+.fabricCell {
+  position: relative;
+  background: #f2d4b6;
+  border-color: rgba(90, 62, 35, 0.25);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.stitchMark {
+  position: relative;
+  display: block;
+  width: 18px;
+  height: 18px;
+}
+
+.knitTexture .stitchMark::before,
+.knitTexture .stitchMark::after {
+  content: "";
+  position: absolute;
+  width: 3px;
+  height: 15px;
+  top: 1px;
+  background: #805b3f;
+  border-radius: 999px;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.14);
+}
+
+.knitTexture .stitchMark::before {
+  left: 5px;
+  transform: rotate(26deg);
+}
+
+.knitTexture .stitchMark::after {
+  right: 5px;
+  transform: rotate(-26deg);
+}
+
+.purlTexture .stitchMark::before {
+  content: "";
+  position: absolute;
+  left: 3px;
+  right: 3px;
+  top: 5px;
+  height: 9px;
+  background: radial-gradient(circle at 50% 35%, #ffe8d2 0%, #d7a882 65%, #bf8862 100%);
+  border-radius: 999px;
+  box-shadow: 0 1px 0 rgba(92, 60, 34, 0.4), inset 0 1px 1px rgba(255, 255, 255, 0.5);
+}
+
 @media (min-width: 960px) {
   .visualizers {
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
### Motivation
- Provide an interactive MVP knitting visualizer that lets users compose stitch charts and preview the resulting fabric surface for flat knitting using only knit/purl stitches.
- Keep the feature lightweight and focused: chart editor (what you work) plus fabric renderer (what is visible on RS/WS) for row-by-row flat knitting.

### Description
- Added a new Next.js page at `pages/projects/knitting-visualizer.tsx` implementing a 2D stitch-chart editor with click-to-toggle `K`/`P` cells, row/column resizing, and `Fill K` / `Fill P` controls.
- Implemented a derived fabric view that computes visible stitches per row by mapping worked stitches to the selected side (`RS` / `WS`) using `oppositeStitch` and `useMemo` for efficient updates.
- Added styles in `styles/KnittingVisualizer.module.css` for the controls, responsive two-panel layout, chart/fabric grids, and distinct `knit` / `purl` visual treatments.
- Linked the new visualizer from the Projects list by updating `pages/projects.tsx` to include an entry for the Knitting Visualizer.

### Testing
- Ran `npm run lint` which completed successfully; only unrelated pre-existing ESLint warnings were reported.
- Launched the app with the dev server (`next dev`) and verified the page renders and compiles without runtime errors.
- Automated browser validation: a Playwright script loaded `/projects/knitting-visualizer`, interacted with a few cells and the side selector, and saved a screenshot confirming the UI and interactions worked as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698545b283348321a56c1ac9c1ac344b)